### PR TITLE
Fix telebot polling type error

### DIFF
--- a/src/bot/telegram_bot.py
+++ b/src/bot/telegram_bot.py
@@ -111,7 +111,7 @@ class TelegramBot:
                 # Use async polling with infinity_polling
                 await self.bot.infinity_polling(
                     timeout=10,
-                    long_polling_timeout=10,
+                    request_timeout=20,
                     logger_level=logging.INFO
                 )
                 


### PR DESCRIPTION
Fix `TypeError` in `infinity_polling` by changing `long_polling_timeout` to `request_timeout`.

The `long_polling_timeout` parameter is not accepted by `AsyncTeleBot._process_polling()`, leading to a `TypeError`. The correct parameter for the HTTP request timeout is `request_timeout`, while `timeout` handles the long polling timeout.

---
<a href="https://cursor.com/background-agent?bcId=bc-b05eb7d2-9aa9-41a4-bf11-74c4d29eca5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b05eb7d2-9aa9-41a4-bf11-74c4d29eca5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

