### PR TITLE
Fix content parser attribute error

### DIFF
--- a/src/processor/content_parser.py
+++ b/src/processor/content_parser.py
@@ -83,3 +83,28 @@ class ContentParser:
             "message_ids": message_ids,
             "content_hash": content_hash
         }
+    
+    def parse_group(self, group) -> Dict:
+        """
+        Parse a MessageGroup into structured content
+        
+        Args:
+            group: MessageGroup object with messages attribute
+        
+        Returns:
+            Parsed content dictionary
+        """
+        return self.parse_message_group(group.messages)
+    
+    def generate_hash(self, content: Dict) -> str:
+        """
+        Generate hash from parsed content dictionary
+        
+        Args:
+            content: Parsed content dictionary (must have 'text' key)
+        
+        Returns:
+            SHA256 hash hex string
+        """
+        text = content.get('text', '')
+        return self.generate_content_hash(text)

--- a/tests/test_content_parser.py
+++ b/tests/test_content_parser.py
@@ -56,3 +56,45 @@ def test_parse_message_group():
     assert len(result["urls"]) == 2
     assert len(result["message_ids"]) == 3
     assert "content_hash" in result
+
+
+def test_parse_group():
+    """Test parsing MessageGroup object"""
+    # Create a mock MessageGroup object
+    class MockMessageGroup:
+        def __init__(self, messages):
+            self.messages = messages
+    
+    messages = [
+        {"message_id": 1, "text": "Test message"},
+        {"message_id": 2, "caption": "Test caption"}
+    ]
+    
+    group = MockMessageGroup(messages)
+    parser = ContentParser()
+    result = parser.parse_group(group)
+    
+    assert "Test message" in result["text"]
+    assert "Test caption" in result["text"]
+    assert len(result["message_ids"]) == 2
+    assert "content_hash" in result
+
+
+def test_generate_hash():
+    """Test generating hash from content dictionary"""
+    parser = ContentParser()
+    
+    content1 = {"text": "Same content", "urls": []}
+    content2 = {"text": "Same content", "urls": ["http://example.com"]}
+    content3 = {"text": "Different content", "urls": []}
+    
+    hash1 = parser.generate_hash(content1)
+    hash2 = parser.generate_hash(content2)
+    hash3 = parser.generate_hash(content3)
+    
+    # Same text = same hash (urls are ignored)
+    assert hash1 == hash2
+    # Different text = different hash
+    assert hash1 != hash3
+    # Valid SHA256 hash
+    assert len(hash1) == 64


### PR DESCRIPTION
Add `parse_group` and `generate_hash` methods to `ContentParser` to resolve `AttributeError` in `BotHandlers`.

The `BotHandlers` class was attempting to call `self.content_parser.parse_group(group)` and `self.content_parser.generate_hash(content)`, but these instance methods did not exist. This PR introduces these methods, which delegate to the existing static methods `parse_message_group` and `generate_content_hash` respectively, ensuring the correct processing of message groups.

---
<a href="https://cursor.com/background-agent?bcId=bc-973e529e-c79b-4346-aa57-9de3084f4a1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-973e529e-c79b-4346-aa57-9de3084f4a1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

