### PR TITLE
Clean up .env.example and remove Qwen api key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,22 +1,3 @@
 # Telegram Bot Configuration
 TELEGRAM_BOT_TOKEN=your_bot_token_here
 ALLOWED_USER_IDS=123456789,987654321
-
-# Agent System (for future LLM integration)
-OPENAI_API_KEY=your_openai_key_here
-ANTHROPIC_API_KEY=your_anthropic_key_here
-
-# Knowledge Base Configuration
-KB_PATH=./knowledge_base
-KB_GIT_ENABLED=true
-KB_GIT_AUTO_PUSH=true
-KB_GIT_REMOTE=origin
-KB_GIT_BRANCH=main
-
-# Processing Configuration
-MESSAGE_GROUP_TIMEOUT=30
-PROCESSED_LOG_PATH=./data/processed.json
-
-# Logging
-LOG_LEVEL=INFO
-LOG_FILE=./logs/bot.log

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -135,7 +135,6 @@ ALLOWED_USER_IDS: ""
 #          Use only for development and testing
 #
 # - "qwen_code": Agent based on Qwen AI via API
-#               Requires QWEN_API_KEY in .env file
 #               Less stable, may have issues with tools
 #
 # - "qwen_code_cli": Agent based on Qwen AI via command line (RECOMMENDED)

--- a/config/settings.py
+++ b/config/settings.py
@@ -78,10 +78,6 @@ class Settings(BaseSettings):
         default=None,
         description="Anthropic API key (from .env or env vars only)"
     )
-    QWEN_API_KEY: Optional[str] = Field(
-        default=None,
-        description="Qwen API key (from .env or env vars only)"
-    )
     GITHUB_TOKEN: Optional[str] = Field(
         default=None,
         description="GitHub personal access token (from .env or env vars only)"

--- a/docs/IMPLEMENTATION_SUMMARY.md
+++ b/docs/IMPLEMENTATION_SUMMARY.md
@@ -143,7 +143,6 @@ AGENT_ENABLE_SHELL: false  # Security
 
 ```bash
 # API Keys
-QWEN_API_KEY=your_qwen_api_key
 GITHUB_TOKEN=your_github_token
 
 # OpenAI-compatible (optional)

--- a/docs/QWEN_CODE_AGENT.md
+++ b/docs/QWEN_CODE_AGENT.md
@@ -200,7 +200,6 @@ AGENT_ENABLE_SHELL: false
 **.env:**
 ```bash
 # API ключи (НЕ в YAML!)
-QWEN_API_KEY=your_qwen_api_key
 GITHUB_TOKEN=your_github_token
 ```
 
@@ -216,7 +215,6 @@ agent = AgentFactory.from_settings(settings)
 agent = AgentFactory.create_agent(
     agent_type="qwen_code",
     config={
-        "api_key": "your_key",
         "model": "qwen-max",
         "instruction": "Custom instruction",
         "enable_web_search": True,
@@ -237,7 +235,6 @@ cp config.example.yaml config.yaml
 nano config.yaml  # установить AGENT_TYPE: "qwen_code"
 
 # 2. Настроить .env
-echo "QWEN_API_KEY=your_key" >> .env
 echo "GITHUB_TOKEN=your_token" >> .env
 
 # 3. Запустить бота

--- a/docs/QWEN_CODE_CLI_INTEGRATION.md
+++ b/docs/QWEN_CODE_CLI_INTEGRATION.md
@@ -126,9 +126,6 @@ AGENT_ENABLE_SHELL: false
 # GitHub токен (для GitHub API)
 GITHUB_TOKEN=your_github_token
 
-# Qwen API ключ (если используется)
-QWEN_API_KEY=your_qwen_api_key
-
 # OpenAI-совместимый API (опционально)
 OPENAI_API_KEY=your_api_key
 OPENAI_BASE_URL=your_base_url

--- a/src/agents/agent_factory.py
+++ b/src/agents/agent_factory.py
@@ -76,7 +76,6 @@ class AgentFactory:
         return QwenCodeAgent(
             config=config,
             instruction=config.get("instruction"),
-            api_key=config.get("api_key"),
             model=config.get("model", "qwen-max"),
             enable_web_search=config.get("enable_web_search", True),
             enable_git=config.get("enable_git", True),
@@ -118,7 +117,6 @@ class AgentFactory:
             Agent instance
         """
         config = {
-            "api_key": settings.QWEN_API_KEY,
             "github_token": settings.GITHUB_TOKEN,
             "model": settings.AGENT_MODEL,
             "instruction": settings.AGENT_INSTRUCTION,

--- a/src/agents/qwen_code_agent.py
+++ b/src/agents/qwen_code_agent.py
@@ -100,7 +100,6 @@ Always work autonomously without asking for clarification.
         self,
         config: Optional[Dict] = None,
         instruction: Optional[str] = None,
-        api_key: Optional[str] = None,
         model: str = "qwen-max",
         enable_web_search: bool = True,
         enable_git: bool = True,
@@ -113,7 +112,6 @@ Always work autonomously without asking for clarification.
         Args:
             config: Configuration dictionary
             instruction: Custom instruction for the agent
-            api_key: API key for Qwen service
             model: Model to use (default: qwen-max)
             enable_web_search: Enable web search tool
             enable_git: Enable git command tool
@@ -123,7 +121,6 @@ Always work autonomously without asking for clarification.
         super().__init__(config)
         
         self.instruction = instruction or self.DEFAULT_INSTRUCTION
-        self.api_key = api_key
         self.model = model
         
         # Tool enablement flags

--- a/tests/test_agent_factory.py
+++ b/tests/test_agent_factory.py
@@ -60,7 +60,6 @@ class TestAgentFactory:
         """Test creating agent from settings (stub)"""
         mock_settings = MagicMock()
         mock_settings.AGENT_TYPE = "stub"
-        mock_settings.QWEN_API_KEY = None
         mock_settings.GITHUB_TOKEN = None
         mock_settings.AGENT_MODEL = "qwen-max"
         mock_settings.AGENT_INSTRUCTION = None
@@ -77,7 +76,6 @@ class TestAgentFactory:
         """Test creating agent from settings (Qwen)"""
         mock_settings = MagicMock()
         mock_settings.AGENT_TYPE = "qwen_code"
-        mock_settings.QWEN_API_KEY = "test-key"
         mock_settings.GITHUB_TOKEN = "github-token"
         mock_settings.AGENT_MODEL = "qwen-plus"
         mock_settings.AGENT_INSTRUCTION = "Custom instruction"
@@ -85,11 +83,12 @@ class TestAgentFactory:
         mock_settings.AGENT_ENABLE_GIT = True
         mock_settings.AGENT_ENABLE_GITHUB = False
         mock_settings.AGENT_ENABLE_SHELL = False
+        mock_settings.AGENT_QWEN_CLI_PATH = "qwen"
+        mock_settings.AGENT_TIMEOUT = 300
         
         agent = AgentFactory.from_settings(mock_settings)
         
         assert isinstance(agent, QwenCodeAgent)
-        assert agent.api_key == "test-key"
         assert agent.model == "qwen-plus"
         assert agent.instruction == "Custom instruction"
         assert not agent.enable_web_search

--- a/tests/test_qwen_code_agent.py
+++ b/tests/test_qwen_code_agent.py
@@ -413,9 +413,3 @@ class TestAgentWithDifferentConfigurations:
         agent = QwenCodeAgent(model="qwen-plus")
         
         assert agent.model == "qwen-plus"
-    
-    def test_with_api_key(self):
-        """Test agent with API key"""
-        agent = QwenCodeAgent(api_key="test-key-123")
-        
-        assert agent.api_key == "test-key-123"


### PR DESCRIPTION
Remove unused `QWEN_API_KEY` references from the codebase and clean up `.env.example`.

The Qwen API key was removed because the Qwen agent now relies solely on the `qwen` CLI tool, which does not require an API key.

---
<a href="https://cursor.com/background-agent?bcId=bc-08f7a92d-6a75-4744-84bf-3c61f5d33e90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-08f7a92d-6a75-4744-84bf-3c61f5d33e90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

