### PR TITLE
Debug pydantic setting type validation error

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -64,8 +64,8 @@ class Settings(BaseSettings):
         default="",
         description="Telegram bot token (from .env or env vars only)"
     )
-    ALLOWED_USER_IDS: Union[str, List[int]] = Field(
-        default="",
+    ALLOWED_USER_IDS: List[int] = Field(
+        default_factory=list,
         description="Comma-separated list of allowed user IDs"
     )
     

--- a/src/bot/settings_manager.py
+++ b/src/bot/settings_manager.py
@@ -20,7 +20,7 @@ class SettingInfo(BaseModel):
     name: str
     field_name: str
     description: str
-    type: Type
+    type: Any  # Changed from Type to Any to accept generic aliases like List[int], Union, etc.
     default: Any
     is_secret: bool = False
     is_readonly: bool = False


### PR DESCRIPTION
Fix Pydantic validation error by updating `ALLOWED_USER_IDS` type annotation and allowing generic aliases in `SettingInfo.type`.

The original `SettingInfo.type` field expected a concrete `Type`, which caused validation failures when inspecting settings fields annotated with generic aliases like `Union[str, List[int]]` or `List[int]`. The `ALLOWED_USER_IDS` field was specifically problematic as its annotation (`Union[str, List[int]]`) didn't match its effective runtime type (`List[int]`) after validation, and `Union` itself is a generic alias. Changing `SettingInfo.type` to `Any` allows it to correctly handle these typing constructs, and updating `ALLOWED_USER_IDS` reflects its true type and provides a proper default.

---
<a href="https://cursor.com/background-agent?bcId=bc-b4c120c7-6db0-4de0-9a0e-4836ecc4e49c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b4c120c7-6db0-4de0-9a0e-4836ecc4e49c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

