### PR TITLE
Fix settings menu and improve usability

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,9 +214,8 @@ Press `Ctrl+C` in the terminal
 | `/setkb <name\|url>` | Setup knowledge base | `/setkb my-notes` or `/setkb https://github.com/user/repo` |
 | `/kb` | Show current KB info | `/kb` |
 | `/status` | Display processing statistics | `/status` |
-| `/settings` | Open settings menu | Interactive menu with all categories |
+| `/settings` | Open interactive settings menu | Navigate through categories and settings |
 | `/viewsettings [category]` | View all or filtered settings | `/viewsettings knowledge_base` |
-| `/setsetting <name> <value>` | Change a setting | `/setsetting KB_GIT_ENABLED true` |
 | `/resetsetting <name>` | Reset to default | `/resetsetting AGENT_TIMEOUT` |
 | `/kbsettings` | KB settings quick access | View and modify KB configuration |
 | `/agentsettings` | Agent settings quick access | View and modify agent configuration |
@@ -230,15 +229,11 @@ Each user can customize bot behavior via Telegram commands:
 ```bash
 # Open interactive settings menu
 /settings
+# Navigate through categories → Select setting → Enter new value
 
 # View all settings or filter by category
 /viewsettings
 /viewsettings knowledge_base
-
-# Change specific settings
-/setsetting KB_GIT_ENABLED true
-/setsetting AGENT_TIMEOUT 600
-/setsetting MESSAGE_GROUP_TIMEOUT 60
 
 # Reset to global defaults
 /resetsetting KB_GIT_AUTO_PUSH
@@ -247,6 +242,14 @@ Each user can customize bot behavior via Telegram commands:
 /kbsettings       # Knowledge Base settings
 /agentsettings    # Agent configuration
 ```
+
+**How Settings Work:**
+1. Use `/settings` to open the interactive menu
+2. Choose a category (Knowledge Base, Agent, Processing, etc.)
+3. Click on any setting to view its details
+4. For boolean settings: Click Enable/Disable buttons
+5. For other settings: Send the new value as a text message
+6. Settings include descriptions, types, and allowed values
 
 **Features:**
 - ✅ **Interactive UI**: Inline keyboards with category navigation

--- a/SETTINGS_MENU_IMPROVEMENTS.md
+++ b/SETTINGS_MENU_IMPROVEMENTS.md
@@ -1,0 +1,191 @@
+# Settings Menu Improvements
+
+## Summary
+
+Fixed the "Back to Menu" button issue and completely redesigned the settings menu interface to provide a more intuitive user experience with drill-down navigation and detailed setting information.
+
+## Changes Made
+
+### 1. Fixed "Back to Menu" Button ✅
+- **Problem**: The "Back to Menu" button in settings categories was not working
+- **Solution**: Added `_show_main_menu()` method and handler for `settings:menu` callback action
+- **File**: `src/bot/settings_handlers.py`
+
+### 2. Removed /setsetting Command ✅
+- **Old behavior**: Users had to type `/setsetting SETTING_NAME value` manually
+- **New behavior**: Interactive menu-based setting modification
+- **Removed**: `handle_set_setting()` method from `SettingsHandlers` class
+- **Files modified**: 
+  - `src/bot/settings_handlers.py`
+  - `README.md` (documentation updated)
+
+### 3. Implemented Drill-Down Navigation ✅
+- **Feature**: Users can now navigate through a hierarchy:
+  1. Main menu → Select category (e.g., "Knowledge Base")
+  2. Category view → Select specific setting (e.g., "KB_GIT_ENABLED")
+  3. Setting detail → View info and modify
+  4. Back navigation at each level
+- **Methods added**:
+  - `_show_main_menu()`: Display main settings menu with categories
+  - `_show_category_settings()`: Show all settings in a category
+  - `_show_setting_detail()`: Display detailed information about a specific setting
+
+### 4. Added Setting Descriptions ✅
+- **Feature**: Each setting now displays its description from pydantic Field definitions
+- **Information shown**:
+  - Setting name
+  - Description (from pydantic Field description)
+  - Type (formatted in user-friendly way)
+  - Current value
+  - Default value
+  - Allowed values or range constraints
+- **Method added**: `_format_type()` to convert Python type annotations to readable strings
+
+### 5. Implemented Interactive Value Input ✅
+- **Boolean settings**: 
+  - Show "Enable" and "Disable" buttons directly in the setting detail view
+  - Instant toggle without text input
+- **Other settings** (int, str, Path, etc.):
+  - Bot prompts user to send new value as text message
+  - State tracking with `waiting_for_input` dictionary
+  - Support for cancellation with `/cancel` command
+- **Method added**: `handle_setting_input()` to process text input for settings
+
+### 6. Enhanced Type Information Display ✅
+- **Type formatting**: 
+  - `bool` → "boolean"
+  - `int` → "integer"
+  - `str` → "string"
+  - `Optional[X]` → "optional X"
+  - `List[X]` → "list of X"
+  - `Path` → "path"
+- **Allowed values**:
+  - For booleans: Shows `true`, `false`
+  - For constrained types: Shows range or allowed values
+  - From pydantic Field validators
+
+## Technical Details
+
+### New Handler Registration
+```python
+# Added text message handler for setting input
+self.bot.message_handler(func=lambda m: m.from_user.id in self.waiting_for_input)(
+    self.handle_setting_input
+)
+```
+
+### State Management
+```python
+# Track users waiting for input: user_id -> (setting_name, category)
+self.waiting_for_input: Dict[int, tuple[str, str]] = {}
+```
+
+### Callback Data Structure
+- `settings:menu` - Show main menu
+- `settings:category:{category_name}` - Show category settings
+- `settings:setting:{setting_name}` - Show setting detail
+- `settings:set:{setting_name}:{value}` - Set setting value (for booleans)
+- `settings:reset:{setting_name}` - Reset setting to default
+
+## User Experience Flow
+
+### Example: Changing AGENT_TIMEOUT Setting
+
+**Before (Old Method)**:
+```
+User: /setsetting AGENT_TIMEOUT 600
+Bot: ✅ Setting AGENT_TIMEOUT updated to: 600
+```
+
+**After (New Method)**:
+```
+1. User: /settings
+2. Bot: Shows menu with categories (Agent, Knowledge Base, etc.)
+3. User: Clicks "🤖 Agent"
+4. Bot: Shows all agent settings with current values
+5. User: Clicks "AGENT_TIMEOUT: 300"
+6. Bot: Shows detailed information:
+   ⚙️ AGENT_TIMEOUT
+   📝 Timeout in seconds for agent operations
+   Type: integer
+   Current value: 300
+   Default value: 300
+   [Buttons: Reset to Default, Back]
+   💬 Please send the new value for AGENT_TIMEOUT
+7. User: 600
+8. Bot: ✅ Setting AGENT_TIMEOUT updated to: 600
+```
+
+### Example: Toggling Boolean Setting
+
+```
+1. User: /settings
+2. Bot: Shows menu with categories
+3. User: Clicks "📚 Knowledge Base"
+4. Bot: Shows KB settings
+5. User: Clicks "KB_GIT_ENABLED: ✅"
+6. Bot: Shows detailed information with buttons:
+   [✅ Enable] [❌ Disable]
+   [Reset to Default] [Back]
+7. User: Clicks "❌ Disable"
+8. Bot: ✅ Setting KB_GIT_ENABLED updated to: False
+```
+
+## Files Modified
+
+1. **src/bot/settings_handlers.py** (Major changes)
+   - Removed: `handle_set_setting()` method
+   - Modified: `handle_settings_callback()` - Added new action handlers
+   - Modified: `_show_category_settings()` - Changed to drill-down interface
+   - Added: `_show_main_menu()` - Main menu callback handler
+   - Added: `_show_setting_detail()` - Show individual setting details
+   - Added: `handle_setting_input()` - Process text input for settings
+   - Added: `_format_type()` - Format type annotations
+   - Modified: Class constructor - Added `waiting_for_input` state tracking
+
+2. **README.md** (Documentation update)
+   - Updated bot commands table
+   - Removed `/setsetting` references
+   - Added explanation of new settings workflow
+   - Added "How Settings Work" section with step-by-step guide
+
+## Benefits
+
+1. **Better UX**: Visual navigation instead of typing commands
+2. **Discoverability**: Users can browse all available settings
+3. **Safety**: Users see current values and descriptions before changing
+4. **Type Safety**: Automatic validation with clear allowed values
+5. **Flexibility**: Quick toggles for booleans, text input for complex types
+6. **Help Text**: Built-in descriptions and type information
+
+## Backward Compatibility
+
+- ✅ `/viewsettings` - Still works (view settings)
+- ✅ `/resetsetting` - Still works (reset to default)
+- ✅ `/kbsettings` - Still works (quick access to KB settings)
+- ✅ `/agentsettings` - Still works (quick access to Agent settings)
+- ❌ `/setsetting` - **REMOVED** (replaced with interactive menu)
+
+## Testing Checklist
+
+- [x] Syntax check passes
+- [ ] "Back to Menu" button works from category view
+- [ ] "Back" button works from setting detail view
+- [ ] Category selection shows correct settings
+- [ ] Setting detail shows correct information
+- [ ] Boolean settings can be toggled with buttons
+- [ ] Text input works for non-boolean settings
+- [ ] Cancel command works during text input
+- [ ] Setting validation works correctly
+- [ ] Type descriptions are clear and accurate
+- [ ] State is cleaned up after setting change
+- [ ] Multiple users can use settings simultaneously
+
+## Future Enhancements
+
+1. Add inline validation hints before user submits value
+2. Show examples of valid values for complex types
+3. Add search/filter in category view for long setting lists
+4. Add "Recent changes" view to show user's modifications
+5. Add bulk reset option to reset all settings at once
+6. Add setting templates for common configurations


### PR DESCRIPTION
Fix 'Back to menu' button and replace `/setsetting` command with an interactive, descriptive settings menu for improved user experience.

The original `/setsetting` command required users to know setting names and their exact values, leading to a poor user experience. This PR introduces a navigable menu that displays setting descriptions, types, and allowed values, making configuration intuitive and discoverable.

---
<a href="https://cursor.com/background-agent?bcId=bc-8363acee-eb9f-4322-b085-2ac71f121a44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8363acee-eb9f-4322-b085-2ac71f121a44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

