### PR TITLE
Fix setting change message handling

### DIFF
--- a/src/bot/handlers.py
+++ b/src/bot/handlers.py
@@ -27,12 +27,14 @@ class BotHandlers:
         bot: AsyncTeleBot, 
         tracker: ProcessingTracker,
         repo_manager: RepositoryManager,
-        user_settings: UserSettings
+        user_settings: UserSettings,
+        settings_handlers=None
     ):
         self.bot = bot
         self.tracker = tracker
         self.repo_manager = repo_manager
         self.user_settings = user_settings
+        self.settings_handlers = settings_handlers
         self.message_aggregator = MessageAggregator(settings.MESSAGE_GROUP_TIMEOUT)
         self.content_parser = ContentParser()
         
@@ -277,6 +279,12 @@ class BotHandlers:
     
     async def handle_text_message(self, message: Message) -> None:
         """Handle regular text messages (async)"""
+        # Check if user is waiting for settings input
+        if self.settings_handlers and message.from_user.id in self.settings_handlers.waiting_for_input:
+            # This message is for settings input, let settings handler process it
+            self.logger.info(f"Skipping text message from user {message.from_user.id} - waiting for settings input")
+            return
+        
         self.logger.info(f"Text message from user {message.from_user.id}: {message.text[:50]}...")
         await self._process_message(message)
     

--- a/src/bot/telegram_bot.py
+++ b/src/bot/telegram_bot.py
@@ -35,8 +35,8 @@ class TelegramBot:
         self.bot = AsyncTeleBot(settings.TELEGRAM_BOT_TOKEN)
         
         # Initialize handlers
-        self.handlers = BotHandlers(self.bot, tracker, repo_manager, user_settings)
         self.settings_handlers = SettingsHandlers(self.bot)
+        self.handlers = BotHandlers(self.bot, tracker, repo_manager, user_settings, self.settings_handlers)
         
         # Bot state
         self.is_running = False
@@ -59,9 +59,9 @@ class TelegramBot:
             # Start background tasks for message aggregator
             self.handlers.start_background_tasks()
             
-            # Register handlers
-            await self.handlers.register_handlers_async()
+            # Register handlers - settings handlers first for proper priority
             await self.settings_handlers.register_handlers_async()
+            await self.handlers.register_handlers_async()
             
             # Start polling
             self.is_running = True


### PR DESCRIPTION
Fix: Prevent regular message processing when user is inputting a setting value.

Previously, when a user was prompted to enter a setting value, the main `handle_text_message` would process it as a regular message, leading to an incorrect "message added to group" notification. This PR ensures that messages intended for setting input are correctly handled by the `SettingsHandlers` by:
1.  Adding a check in `BotHandlers.handle_text_message` to skip processing if the user is in `settings_handlers.waiting_for_input` state.
2.  Registering `SettingsHandlers` before `BotHandlers` to ensure correct handler priority.

---
<a href="https://cursor.com/background-agent?bcId=bc-dfc6d625-6bf5-474e-80fa-d767d61a29e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-dfc6d625-6bf5-474e-80fa-d767d61a29e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

