### PR TITLE
Fix syntax error in handlers.py

### DIFF
--- a/src/bot/handlers.py
+++ b/src/bot/handlers.py
@@ -43,7 +43,7 @@ class BotHandlers:
         # Store per-user agents
         self.user_agents: Dict[int, Any] = {}
         self.content_parser = ContentParser()
-        self.        
+        self.logger = logger
         self.logger.info(f"BotHandlers initialized with user-specific settings support")
     
     async def register_handlers_async(self):


### PR DESCRIPTION
Fix `SyntaxError` by completing the logger initialization in `BotHandlers`.

The `SyntaxError` was caused by an incomplete `self.` statement. This PR completes the statement by assigning the imported `logger` instance to `self.logger`, which is consistent with the logger's usage throughout the class.

---
<a href="https://cursor.com/background-agent?bcId=bc-2b15b5c2-c379-42d1-a9b1-8b306141fd94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2b15b5c2-c379-42d1-a9b1-8b306141fd94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

