### PR TITLE
Process qwen code cli agent content

### DIFF
--- a/src/agents/qwen_code_cli_agent.py
+++ b/src/agents/qwen_code_cli_agent.py
@@ -163,10 +163,18 @@ class QwenCodeCLIAgent(BaseAgent):
             
             # Step 3: Parse agent response using BaseAgent method
             logger.debug("[QwenCodeCLIAgent] STEP 3: Parsing agent response with standard parser")
-            agent_result = self.parse_agent_response(result_text)
-            logger.info(f"[QwenCodeCLIAgent] Parsed result: {agent_result.summary}")
-            logger.debug(f"[QwenCodeCLIAgent] Files created: {agent_result.files_created}")
-            logger.debug(f"[QwenCodeCLIAgent] Folders created: {agent_result.folders_created}")
+            logger.debug(f"[QwenCodeCLIAgent] Result text preview (first 500 chars): {result_text[:500]}")
+            logger.debug(f"[QwenCodeCLIAgent] Result text preview (last 500 chars): {result_text[-500:]}")
+            
+            try:
+                agent_result = self.parse_agent_response(result_text)
+                logger.info(f"[QwenCodeCLIAgent] Parsed result: {agent_result.summary}")
+                logger.debug(f"[QwenCodeCLIAgent] Files created: {agent_result.files_created}")
+                logger.debug(f"[QwenCodeCLIAgent] Folders created: {agent_result.folders_created}")
+            except Exception as parse_error:
+                logger.error(f"[QwenCodeCLIAgent] Failed to parse agent response: {parse_error}", exc_info=True)
+                logger.debug(f"[QwenCodeCLIAgent] Full response text: {result_text}")
+                raise
             
             # Step 4: Extract KB structure from response
             logger.debug("[QwenCodeCLIAgent] STEP 4: Extracting KB structure from response")


### PR DESCRIPTION
Add robust JSON parsing and error handling for agent responses to prevent crashes from malformed `agent-result` blocks.

Previously, if an `agent-result` JSON block contained a simple string (e.g., `"summary"`) instead of a dictionary, `json.loads()` would successfully parse it as a Python string. Subsequent code would then attempt to call `.get("summary", "")` on this string, resulting in an `AttributeError`. This PR introduces a type check to ensure the parsed `result_data` is a dictionary before attempting dictionary-specific operations, and enhances logging for better debugging of parsing issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-8e0a0597-703f-463b-a01d-a0eaea19f4a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8e0a0597-703f-463b-a01d-a0eaea19f4a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

