### PR TITLE
Fix agent prompt brace errors

### DIFF
--- a/config/agent_prompts.py
+++ b/config/agent_prompts.py
@@ -45,17 +45,17 @@ STANDARDIZED RESULT FORMAT:
 After completing all actions, you MUST return the result in this format:
 
 ```agent-result
-{
+{{
   "summary": "Brief description of what you did (3-5 sentences)",
   "files_created": ["path/to/file1.md", "path/to/file2.md"],
   "files_edited": ["path/to/file3.md"],
   "folders_created": ["path/to/folder1", "path/to/folder2"],
-  "metadata": {
+  "metadata": {{
     "category": "main_category",
     "topics": ["topic1", "topic2"],
     "sources_analyzed": 3
-  }
-}
+  }}
+}}
 ```
 
 And also add KB metadata block:
@@ -172,17 +172,17 @@ QWEN_CODE_CLI_AGENT_INSTRUCTION = """Ты автономный агент для
 В конце своего ответа добавь блок:
 
 ```agent-result
-{
+{{
   "summary": "Краткое описание что ты сделал (3-5 предложений)",
   "files_created": ["путь/к/файлу1.md", "путь/к/файлу2.md"],
   "files_edited": ["путь/к/файлу3.md"],
   "folders_created": ["путь/к/папке1", "путь/к/папке2"],
-  "metadata": {
+  "metadata": {{
     "category": "основная_категория",
     "topics": ["тема1", "тема2"],
     "sources_analyzed": 3
-  }
-}
+  }}
+}}
 ```
 
 И также добавь блок с метаданными KB:
@@ -307,16 +307,16 @@ CONTENT_PROCESSING_PROMPT_TEMPLATE = """
 ОБЯЗАТЕЛЬНО верни результат в конце в СТАНДАРТИЗИРОВАННОМ ФОРМАТЕ:
 
 ```agent-result
-{
+{{
   "summary": "Краткое описание что ты сделал",
   "files_created": ["путь/к/файлу1.md", "путь/к/файлу2.md"],
   "files_edited": ["путь/к/файлу3.md"],
   "folders_created": ["путь/к/папке1"],
-  "metadata": {
+  "metadata": {{
     "category": "основная_категория",
     "topics": ["тема1", "тема2"]
-  }
-}
+  }}
+}}
 ```
 
 ```metadata


### PR DESCRIPTION
Escape braces in agent prompt JSON examples to prevent Python string formatting errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-28044738-f32c-4d29-abc1-f00d01ea0af1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-28044738-f32c-4d29-abc1-f00d01ea0af1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

