### PR TITLE
Fix forwarded message handling

### DIFF
--- a/src/bot/handlers.py
+++ b/src/bot/handlers.py
@@ -55,8 +55,9 @@ class BotHandlers:
         self.bot.message_handler(commands=['setkb'])(self.handle_setkb)
         self.bot.message_handler(commands=['kb'])(self.handle_kb_info)
         
-        # Forwarded messages - register first to catch all forwarded content
-        self.bot.message_handler(func=lambda m: self._is_forwarded_message(m))(self.handle_forwarded_message)
+        # Forwarded messages - register first to catch all forwarded content types we support
+        # Explicitly include photo and document so forwarded media are handled here
+        self.bot.message_handler(content_types=['text', 'photo', 'document'], func=lambda m: self._is_forwarded_message(m))(self.handle_forwarded_message)
         
         # Regular message handlers - only for non-forwarded messages and non-command messages
         self.bot.message_handler(func=lambda m: m.content_type == 'text' and not self._is_forwarded_message(m) and not self._is_command_message(m))(self.handle_text_message)


### PR DESCRIPTION
Add explicit content types to the forwarded message handler to correctly process forwarded photos and documents.

The forwarded message handler previously defaulted to only processing text. Since other photo and document handlers explicitly ignored forwarded messages, forwarded media (photos, documents) were not being handled at all. This change ensures they are now correctly routed to `handle_forwarded_message`.

---
<a href="https://cursor.com/background-agent?bcId=bc-0671a2ad-cdf7-431d-b0e5-500e16567d70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0671a2ad-cdf7-431d-b0e5-500e16567d70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

