### PR TITLE
Handle package build error in non-package mode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,11 @@ Repository = "https://github.com/ArtyomZemlyak/tg-note"
 tg-note = "main:main"
 
 [tool.poetry]
-package-mode = false
+packages = [
+    { include = "src" },
+    { include = "config" },
+    { include = "main.py", format = "sdist" }
+]
 
 [tool.poetry.dependencies]
 python = "^3.11"


### PR DESCRIPTION
Enable Poetry package building by removing `package-mode = false` and configuring package sources in `pyproject.toml`.

The `pyproject.toml` previously had `package-mode = false`, which explicitly disabled package building. This conflicted with the GitHub Actions workflow that attempts to run `poetry build` for PyPI publication. The changes allow Poetry to correctly identify and build the package by specifying the `src`, `config` directories, and `main.py` as package components.

---
<a href="https://cursor.com/background-agent?bcId=bc-ab4f37f3-32f1-4af6-9cd2-ec027c8b19ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ab4f37f3-32f1-4af6-9cd2-ec027c8b19ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

