### PR TITLE
Fix OIDC token permissions for publishing

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -13,6 +13,9 @@ jobs:
     name: Build and publish package to PyPI
     runs-on: ubuntu-latest
     
+    permissions:
+      id-token: write
+    
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -48,5 +51,4 @@ jobs:
       - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
           verbose: true


### PR DESCRIPTION
Configure PyPI publishing for trusted publishing by adding `id-token: write` permission and removing the `password` parameter.

This fixes the "missing or insufficient OIDC token permissions" error, enabling secure trusted publishing to PyPI instead of using API tokens.

---
<a href="https://cursor.com/background-agent?bcId=bc-b1ed5c8d-8cee-4485-b75b-a4893b55eeb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b1ed5c8d-8cee-4485-b75b-a4893b55eeb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

