### PR TITLE
Fix trusted publisher configuration error

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -12,6 +12,9 @@ jobs:
   build-and-publish:
     name: Build and publish package to PyPI
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/tg-note
     
     permissions:
       id-token: write

--- a/PYPI_SETUP.md
+++ b/PYPI_SETUP.md
@@ -1,0 +1,68 @@
+# Quick Fix for PyPI Trusted Publisher Error
+
+## The Problem
+
+The error occurs because PyPI doesn't have a trusted publisher configured that matches the claims from GitHub Actions.
+
+## The Solution
+
+### 1. Update GitHub Actions Workflow ✅ DONE
+
+The workflow has been updated to include an environment named `pypi`.
+
+### 2. Configure PyPI Trusted Publisher
+
+You need to configure a trusted publisher on PyPI with these **exact** values:
+
+| Field | Value |
+|-------|-------|
+| **PyPI Project Name** | `tg-note` |
+| **Owner** | `ArtyomZemlyak` |
+| **Repository name** | `tg-note` |
+| **Workflow name** | `publish-to-pypi.yml` |
+| **Environment name** | `pypi` |
+
+#### Steps:
+
+1. **For a new package** (first time publishing):
+   - Go to: https://pypi.org/manage/account/publishing/
+   - Click "Add a pending publisher"
+   - Fill in the values above
+
+2. **For an existing package**:
+   - Go to: https://pypi.org/manage/project/tg-note/settings/
+   - Scroll to "Publishing" section
+   - Click "Add a new publisher"
+   - Fill in the values above
+
+### 3. Create GitHub Environment
+
+1. Go to: https://github.com/ArtyomZemlyak/tg-note/settings/environments
+2. Click "New environment"
+3. Name it: `pypi`
+4. (Optional) Add protection rules for security
+
+### 4. Test the Configuration
+
+After completing steps 2 and 3, you can test by:
+
+```bash
+# Delete and recreate the tag
+git tag -d v0.0.1
+git push origin :refs/tags/v0.0.1
+git tag v0.0.1
+git push origin v0.0.1
+```
+
+Or create a new release through GitHub UI.
+
+## Why This Happened
+
+The original workflow didn't specify an environment, which is a best practice for PyPI publishing. The environment provides:
+- Better security through GitHub environment protection rules
+- Clear separation of deployment concerns
+- Audit trail for deployments
+
+## More Information
+
+See the comprehensive guide at: `docs_site/deployment/pypi-trusted-publisher-setup.md`

--- a/docs_site/deployment/cicd.md
+++ b/docs_site/deployment/cicd.md
@@ -1,5 +1,68 @@
-# Coming Soon
+# CI/CD Pipeline
 
-This documentation page is under construction.
+This document describes the continuous integration and deployment pipelines for the tg-note project.
 
-For now, please refer to the [README](https://github.com/ArtyomZemlyak/tg-note) or check back later.
+## GitHub Actions Workflows
+
+### Publish to PyPI
+
+The project uses GitHub Actions to automatically publish releases to PyPI using Trusted Publishing (OIDC authentication).
+
+**Workflow file**: `.github/workflows/publish-to-pypi.yml`
+
+**Triggers**:
+- When a new release is published on GitHub
+- Manual workflow dispatch
+
+**What it does**:
+1. Checks out the repository
+2. Sets up Python 3.11
+3. Installs Poetry and project dependencies
+4. Builds the distribution packages
+5. Publishes to PyPI using trusted publishing (no API tokens required)
+
+**Environment**: `pypi`
+
+For detailed setup instructions, see [PyPI Trusted Publisher Setup](pypi-trusted-publisher-setup.md).
+
+## Setting Up CI/CD
+
+### PyPI Publishing
+
+To enable automatic publishing to PyPI:
+
+1. Configure a trusted publisher on PyPI (see [setup guide](pypi-trusted-publisher-setup.md))
+2. Create a `pypi` environment in GitHub repository settings
+3. (Optional) Add protection rules to the environment
+
+### Creating a Release
+
+To trigger a new PyPI release:
+
+1. **Via GitHub UI**:
+   - Go to Releases → Draft a new release
+   - Create a new tag (e.g., `v0.1.0`)
+   - Publish the release
+
+2. **Via Git CLI**:
+   ```bash
+   git tag v0.1.0
+   git push origin v0.1.0
+   ```
+
+3. **Via GitHub CLI**:
+   ```bash
+   gh release create v0.1.0 --title "Release v0.1.0" --notes "Release notes here"
+   ```
+
+The workflow will automatically build and publish the package to PyPI.
+
+## Future Improvements
+
+Potential additions to the CI/CD pipeline:
+
+- Automated testing on pull requests
+- Code quality checks (linting, type checking)
+- Documentation deployment
+- Docker image building and publishing
+- Automated changelog generation

--- a/docs_site/deployment/pypi-trusted-publisher-setup.md
+++ b/docs_site/deployment/pypi-trusted-publisher-setup.md
@@ -1,0 +1,131 @@
+# PyPI Trusted Publisher Setup
+
+This guide explains how to configure PyPI Trusted Publishing for the `tg-note` package.
+
+## What is Trusted Publishing?
+
+Trusted Publishing is a secure authentication method that allows GitHub Actions to publish packages to PyPI without using API tokens. It uses OpenID Connect (OIDC) to verify the identity of the publisher.
+
+## Prerequisites
+
+1. A PyPI account with permissions to manage the `tg-note` package
+2. The package must either already exist on PyPI or you need permission to register it
+
+## Configuration Steps
+
+### Step 1: Access PyPI Trusted Publisher Settings
+
+1. Go to [PyPI](https://pypi.org/) and log in
+2. Navigate to your account settings
+3. Go to "Publishing" section
+
+### Step 2: Add a New Trusted Publisher
+
+Choose one of these options:
+
+#### Option A: For an Existing Package
+
+1. Go to your package page: https://pypi.org/manage/project/tg-note/settings/
+2. Scroll to "Publishing" section
+3. Click "Add a new publisher"
+
+#### Option B: For a New Package (Pending Publisher)
+
+1. Go to: https://pypi.org/manage/account/publishing/
+2. Click "Add a pending publisher"
+3. This allows you to configure the trusted publisher before the first release
+
+### Step 3: Configure the Publisher
+
+Fill in the following details **exactly** as shown:
+
+| Field | Value |
+|-------|-------|
+| **PyPI Project Name** | `tg-note` |
+| **Owner** | `ArtyomZemlyak` |
+| **Repository name** | `tg-note` |
+| **Workflow name** | `publish-to-pypi.yml` |
+| **Environment name** | `pypi` |
+
+### Step 4: Verify Configuration
+
+After adding the publisher, verify the configuration matches these claims:
+
+```yaml
+repository: ArtyomZemlyak/tg-note
+workflow_ref: ArtyomZemlyak/tg-note/.github/workflows/publish-to-pypi.yml@refs/tags/v*
+environment: pypi
+```
+
+### Step 5: Create GitHub Environment
+
+1. Go to your GitHub repository: https://github.com/ArtyomZemlyak/tg-note
+2. Navigate to Settings → Environments
+3. Click "New environment"
+4. Name it `pypi`
+5. (Optional) Add protection rules:
+   - Require reviewers before deployment
+   - Restrict to specific branches (e.g., only tags matching `v*`)
+
+## Testing the Configuration
+
+### Create a Test Release
+
+```bash
+# Create and push a new tag
+git tag v0.0.2
+git push origin v0.0.2
+```
+
+Or create a release through the GitHub UI:
+1. Go to Releases
+2. Click "Draft a new release"
+3. Create a new tag (e.g., `v0.0.2`)
+4. Publish the release
+
+The workflow will automatically trigger and publish to PyPI using trusted publishing.
+
+## Troubleshooting
+
+### Error: "invalid-publisher: valid token, but no corresponding publisher"
+
+This means the configuration on PyPI doesn't match the claims being sent. Verify:
+
+1. **Package name** matches exactly: `tg-note`
+2. **Repository** is correct: `ArtyomZemlyak/tg-note`
+3. **Workflow file** path is exact: `publish-to-pypi.yml` (not `.github/workflows/publish-to-pypi.yml`)
+4. **Environment name** matches: `pypi`
+5. The trusted publisher is active (not expired or disabled)
+
+### Error: "environment-not-found"
+
+Create the `pypi` environment in your GitHub repository settings.
+
+### Error: "workflow-not-found"
+
+Ensure the workflow file exists at `.github/workflows/publish-to-pypi.yml` in your repository.
+
+## Security Best Practices
+
+1. **Use environments**: Always specify an environment for publishing workflows
+2. **Add protection rules**: Require reviews for deployments to the `pypi` environment
+3. **Limit workflow permissions**: The workflow only requests `id-token: write` permission
+4. **Monitor releases**: Regularly check your PyPI package for unexpected uploads
+
+## Manual Workflow Trigger
+
+You can also manually trigger the workflow:
+
+```bash
+# Through GitHub CLI
+gh workflow run publish-to-pypi.yml
+
+# Or through the GitHub UI
+# Go to Actions → Publish to PyPI → Run workflow
+```
+
+## References
+
+- [PyPI Trusted Publishers Documentation](https://docs.pypi.org/trusted-publishers/)
+- [PyPI Trusted Publishers Troubleshooting](https://docs.pypi.org/trusted-publishers/troubleshooting/)
+- [GitHub Actions OIDC Documentation](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect)


### PR DESCRIPTION
Add a `pypi` environment to the PyPI publishing workflow and provide documentation to fix the `invalid-publisher` error in trusted publishing.

The `invalid-publisher` error occurred because the GitHub Actions workflow was not sending an `environment` claim, which is required for PyPI trusted publishing configuration to match. By adding an `environment: pypi` to the workflow, the claims will now match the expected PyPI configuration, enabling successful trusted publishing. New documentation guides the user through the necessary PyPI and GitHub environment setup.

---
<a href="https://cursor.com/background-agent?bcId=bc-fb915a76-5a7a-4ccf-b246-c3cbae4cdedd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fb915a76-5a7a-4ccf-b246-c3cbae4cdedd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

