### PR TITLE
Configure qwen-coder-cli approval and project root

### DIFF
--- a/QWEN_CLI_FIXES_SUMMARY.md
+++ b/QWEN_CLI_FIXES_SUMMARY.md
@@ -1,0 +1,217 @@
+# Qwen CLI Agent Fixes and Improvements
+
+**Date:** 2025-10-06  
+**Branch:** cursor/configure-qwen-coder-cli-approval-and-project-root-3db7
+
+## Summary
+
+Fixed critical issues with qwen-code-cli agent integration that caused:
+1. Files being created in the wrong directory (project root instead of user's knowledge base)
+2. Lack of documentation about required approval mode configuration
+
+## Issues Fixed
+
+### Issue 1: Files Created in Wrong Location
+
+**Problem:**
+- qwen-code-cli was creating files relative to the bot's working directory (project root)
+- Files were ending up in paths like `ai/models/granite-4.0.md` instead of `knowledge_bases/my-note/ai/models/granite-4.0.md`
+- This happened because the CLI's working directory was not set to the user's knowledge base path
+
+**Root Cause:**
+- The `QwenCodeCLIAgent` was initialized with `working_directory=os.getcwd()` by default
+- This working directory was set once at agent creation and never changed
+- Each user might have a different KB path, and the same user might switch between KBs
+- The agent is cached per user, so the working directory couldn't be set at initialization time
+
+**Solution:**
+1. Added `set_working_directory()` and `get_working_directory()` methods to `QwenCodeCLIAgent`
+2. Modified `NoteCreationService` to dynamically set the working directory to the user's KB path before processing
+3. Now the CLI runs inside the correct knowledge base directory, ensuring files are created in the right location
+
+**Files Changed:**
+- `src/agents/qwen_code_cli_agent.py`: Added setter/getter methods for working_directory
+- `src/services/note_creation_service.py`: Added call to `set_working_directory()` before agent processing
+- `tests/test_qwen_code_cli_agent.py`: Added tests for working directory functionality
+
+### Issue 2: Missing Approval Mode Documentation
+
+**Problem:**
+- qwen-code-cli requires manual approval for each action by default (interactive mode)
+- The bot cannot interact with CLI in interactive mode, causing it to hang
+- Users were not aware they needed to configure `/approval-mode yolo`
+
+**Solution:**
+- Added comprehensive documentation about `/approval-mode` requirement in installation steps
+- Explained why `yolo` mode is necessary (bot runs autonomously without user interaction)
+- Added warnings about security implications of `yolo` mode
+- Documented all available approval modes and their use cases
+- Referenced official qwen-code-cli documentation
+
+**Files Changed:**
+- `docs_site/agents/qwen-code-cli.md`: Added installation step 5 with approval mode configuration
+- `docs_site/agents/qwen-code-cli.md`: Added troubleshooting section
+
+## Code Changes
+
+### 1. `src/agents/qwen_code_cli_agent.py`
+
+Added methods to dynamically update working directory:
+
+```python
+def set_working_directory(self, working_directory: str) -> None:
+    """Update working directory for qwen CLI execution"""
+    self.working_directory = working_directory
+    logger.info(f"Working directory updated to: {self.working_directory}")
+
+def get_working_directory(self) -> str:
+    """Get current working directory"""
+    return self.working_directory
+```
+
+### 2. `src/services/note_creation_service.py`
+
+Added working directory update before processing:
+
+```python
+user_agent = self.user_context_manager.get_or_create_agent(user_id)
+
+# Set working directory to user's KB path for qwen-code-cli agent
+# This ensures files created by the CLI are in the correct location
+if hasattr(user_agent, 'set_working_directory'):
+    user_agent.set_working_directory(str(kb_path))
+    self.logger.debug(f"Set agent working directory to: {kb_path}")
+
+processed_content = await user_agent.process(content)
+```
+
+### 3. `tests/test_qwen_code_cli_agent.py`
+
+Added tests for working directory functionality:
+
+```python
+def test_set_working_directory(self, agent):
+    """Test setting working directory dynamically"""
+    # ...
+
+def test_working_directory_persistence(self, mock_cli_check):
+    """Test that working directory persists across method calls"""
+    # ...
+```
+
+## Documentation Updates
+
+### 1. Installation Instructions
+
+Added critical step for approval mode configuration:
+
+```markdown
+### 5. Configure Approval Mode (IMPORTANT!)
+
+**⚠️ КРИТИЧЕСКИ ВАЖНО:** Для корректной работы CLI с ботом необходимо настроить режим одобрения инструментов:
+
+\`\`\`bash
+qwen
+/approval-mode yolo --project
+\`\`\`
+```
+
+### 2. How It Works Section
+
+Updated workflow to explain working directory handling:
+
+```markdown
+1. Message received
+2. Agent prepares prompt
+3. CLI working directory set to user's knowledge base path
+4. Calls `qwen` CLI in KB directory
+5. Qwen creates TODO plan
+6. Executes plan with tools (files created in correct KB location)
+7. Returns structured markdown
+8. Saved to KB
+```
+
+### 3. Troubleshooting Section
+
+Added comprehensive troubleshooting guide covering:
+- Files created in wrong location
+- CLI requires manual approval
+- Authentication issues
+- CLI not found errors
+
+## Testing
+
+### Test Coverage
+
+1. **Unit Tests:**
+   - `test_set_working_directory`: Verifies working directory can be changed dynamically
+   - `test_working_directory_persistence`: Ensures working directory persists correctly
+
+2. **Manual Testing Checklist:**
+   - [ ] Create note with qwen-cli agent
+   - [ ] Verify files are created in `knowledge_bases/<kb-name>/` directory
+   - [ ] Verify file structure matches expected KB structure
+   - [ ] Test with multiple users and different KB paths
+   - [ ] Verify agent caching still works correctly
+
+## Impact
+
+### Before Fix
+- Files created in: `/workspace/ai/models/granite-4.0.md`
+- Required manual intervention for every CLI action
+- Users confused about setup requirements
+
+### After Fix
+- Files created in: `/workspace/knowledge_bases/my-note/ai/models/granite-4.0.md`
+- CLI runs autonomously with proper configuration
+- Clear documentation guides users through setup
+
+## Migration Notes
+
+**For existing users:**
+
+1. Update to latest version
+2. Configure approval mode:
+   ```bash
+   qwen
+   /approval-mode yolo --project
+   ```
+3. No code changes needed - working directory is now set automatically
+
+**Backward Compatibility:**
+- ✅ Fully backward compatible
+- The `set_working_directory()` method is only called if the agent supports it (using `hasattr` check)
+- Existing agents without this method will continue to work (though with the old behavior)
+
+## Security Considerations
+
+**Approval Mode:**
+- Using `yolo` mode gives the agent full access to file operations and commands
+- Users should be aware of the security implications
+- Documentation includes clear warnings and references to official docs
+- Users can limit access by:
+  - Using project-scoped approval (`--project`)
+  - Running bot in isolated environment
+  - Reviewing agent prompts and configurations
+
+## Future Improvements
+
+1. Consider adding configuration option to restrict which directories the CLI can access
+2. Add logging of all file operations performed by the CLI
+3. Consider implementing a whitelist of allowed file paths
+4. Add metrics/monitoring for CLI operations
+
+## References
+
+- Issue reported by user on 2025-10-06
+- qwen-code-cli documentation: https://github.com/QwenLM/qwen-code
+- Related discussion in: `docs_site/agents/qwen-cli-debug-trace.md`
+
+## Checklist
+
+- [x] Code changes implemented
+- [x] Tests added
+- [x] Documentation updated
+- [x] Security warnings added
+- [x] Backward compatibility maintained
+- [x] User migration path documented

--- a/docs_site/agents/qwen-code-cli.md
+++ b/docs_site/agents/qwen-code-cli.md
@@ -57,6 +57,35 @@ qwen
 
 Follow the prompts to authenticate via qwen.ai.
 
+### 5. Configure Approval Mode (IMPORTANT!)
+
+**⚠️ КРИТИЧЕСКИ ВАЖНО:** Для корректной работы CLI с ботом необходимо настроить режим одобрения инструментов:
+
+```bash
+qwen
+/approval-mode yolo --project
+```
+
+**Зачем это нужно?**
+- CLI по умолчанию требует ручного подтверждения для каждого действия
+- Бот работает в автономном режиме и не может взаимодействовать с CLI интерактивно
+- Режим `yolo` автоматически одобряет все операции агента
+
+**⚠️ Внимание!** Использование режима `yolo` - на ваш страх и риск. Агент получит полный доступ к файловым операциям и командам.
+
+**Доступные режимы одобрения:**
+- `plan` - только анализ, без изменения файлов
+- `default` - требует подтверждения для редактирования файлов и команд
+- `auto-edit` - автоматически одобряет редактирование файлов
+- `yolo` - автоматически одобряет все операции (требуется для бота)
+
+**Области применения:**
+- `--session` - только для текущей сессии
+- `--project` - для текущего проекта (рекомендуется)
+- `--user` - для всех проектов пользователя
+
+**Рекомендуется ознакомиться с [официальной документацией qwen-code-cli](https://github.com/QwenLM/qwen-code) для полного понимания возможностей и ограничений.**
+
 ---
 
 ## Configuration
@@ -81,11 +110,67 @@ Tip: The CLI path is configurable via `AGENT_QWEN_CLI_PATH` and defaults to `qwe
 
 1. Message received
 2. Agent prepares prompt
-3. Calls `qwen` CLI
-4. Qwen creates TODO plan
-5. Executes plan with tools
-6. Returns structured markdown
-7. Saved to KB
+3. CLI working directory set to user's knowledge base path
+4. Calls `qwen` CLI in KB directory
+5. Qwen creates TODO plan
+6. Executes plan with tools (files created in correct KB location)
+7. Returns structured markdown
+8. Saved to KB
+
+**Important:** The CLI automatically runs inside your knowledge base directory (`knowledge_bases/your-kb-name/`). This ensures that any files created by the agent are saved to the correct location in your knowledge base structure.
+
+---
+
+## Troubleshooting
+
+### Files Created in Wrong Location
+
+**Проблема:** CLI создаёт файлы в корне проекта, а не в `knowledge_bases/your-kb-name/`
+
+**Решение:** Это было исправлено в последней версии. Бот автоматически устанавливает рабочую директорию CLI в путь вашей базы знаний перед каждым запросом. Убедитесь, что вы используете актуальную версию бота.
+
+**Как это работает:**
+- При обработке сообщения бот определяет путь к вашей базе знаний
+- Перед вызовом `qwen` CLI устанавливается `working_directory` в этот путь
+- Все файлы, созданные агентом, попадают в правильную структуру KB
+
+### CLI Requires Manual Approval
+
+**Проблема:** CLI требует подтверждения каждого действия, бот зависает
+
+**Решение:** Настройте режим `yolo` как описано в разделе установки:
+```bash
+qwen
+/approval-mode yolo --project
+```
+
+**Почему это необходимо:**
+- CLI по умолчанию работает в интерактивном режиме
+- Бот не может взаимодействовать с CLI в интерактивном режиме
+- Режим `yolo` отключает все запросы подтверждения
+
+### Authentication Issues
+
+**Проблема:** CLI не может авторизоваться
+
+**Решение:**
+1. Запустите `qwen` в терминале
+2. Следуйте инструкциям для OAuth авторизации через qwen.ai
+3. Либо настройте OpenAI-совместимый API:
+   ```bash
+   export OPENAI_API_KEY="your-key"
+   export OPENAI_BASE_URL="your-url"
+   ```
+
+### CLI Not Found
+
+**Проблема:** `qwen: command not found`
+
+**Решение:**
+1. Проверьте установку: `npm list -g @qwen-code/qwen-code`
+2. Переустановите: `npm install -g @qwen-code/qwen-code@latest`
+3. Проверьте PATH: `echo $PATH`
+4. Если используете nvm: убедитесь, что Node.js активирован
 
 ---
 

--- a/src/agents/qwen_code_cli_agent.py
+++ b/src/agents/qwen_code_cli_agent.py
@@ -518,6 +518,20 @@ class QwenCodeCLIAgent(BaseAgent):
         """Get current instruction"""
         return self.instruction
     
+    def set_working_directory(self, working_directory: str) -> None:
+        """
+        Update working directory for qwen CLI execution
+        
+        Args:
+            working_directory: Path to working directory
+        """
+        self.working_directory = working_directory
+        logger.info(f"Working directory updated to: {self.working_directory}")
+    
+    def get_working_directory(self) -> str:
+        """Get current working directory"""
+        return self.working_directory
+    
     @staticmethod
     def check_installation() -> bool:
         """

--- a/src/services/note_creation_service.py
+++ b/src/services/note_creation_service.py
@@ -113,6 +113,12 @@ class NoteCreationService(INoteCreationService):
             
             user_agent = self.user_context_manager.get_or_create_agent(user_id)
             
+            # Set working directory to user's KB path for qwen-code-cli agent
+            # This ensures files created by the CLI are in the correct location
+            if hasattr(user_agent, 'set_working_directory'):
+                user_agent.set_working_directory(str(kb_path))
+                self.logger.debug(f"Set agent working directory to: {kb_path}")
+            
             try:
                 processed_content = await user_agent.process(content)
             except Exception as agent_error:

--- a/tests/test_qwen_code_cli_agent.py
+++ b/tests/test_qwen_code_cli_agent.py
@@ -421,3 +421,33 @@ class TestQwenCodeCLIAgentWithDifferentConfigurations:
         
         assert agent.config["github_token"] == "test-token"
         assert agent.config["custom_key"] == "custom_value"
+    
+    def test_set_working_directory(self, agent):
+        """Test setting working directory dynamically"""
+        original_dir = agent.get_working_directory()
+        
+        # Set new working directory
+        new_dir = "/tmp/knowledge_base/my-kb"
+        agent.set_working_directory(new_dir)
+        
+        # Verify it was updated
+        assert agent.get_working_directory() == new_dir
+        assert agent.working_directory == new_dir
+        
+        # Restore original
+        agent.set_working_directory(original_dir)
+        assert agent.get_working_directory() == original_dir
+    
+    def test_working_directory_persistence(self, mock_cli_check):
+        """Test that working directory persists across method calls"""
+        agent = QwenCodeCLIAgent(working_directory="/initial/path")
+        
+        # Change working directory
+        agent.set_working_directory("/new/path")
+        
+        # Verify it's still the new path
+        assert agent.get_working_directory() == "/new/path"
+        
+        # Call other methods and verify working directory hasn't changed
+        instruction = agent.get_instruction()
+        assert agent.get_working_directory() == "/new/path"


### PR DESCRIPTION
Fix Qwen Code CLI agent to create files in the correct knowledge base directory and document the required `/approval-mode yolo` configuration.

The `qwen-code-cli` agent was creating files in the bot's root directory instead of the user's knowledge base. This PR dynamically sets the CLI's working directory to the user's knowledge base path before execution. Additionally, the CLI's default interactive approval mode caused the bot to hang, so documentation was added to instruct users to set `/approval-mode yolo` for autonomous operation, including security warnings.

---
<a href="https://cursor.com/background-agent?bcId=bc-b1b8a8fb-2065-485b-9b9a-a8d143b670ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b1b8a8fb-2065-485b-9b9a-a8d143b670ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

