### PR TITLE
Refactor agent prompts for structure and usability

### DIFF
--- a/src/services/question_answering_service.py
+++ b/src/services/question_answering_service.py
@@ -13,7 +13,7 @@ from src.services.interfaces import IQuestionAnsweringService, IUserContextManag
 from src.processor.message_aggregator import MessageGroup
 from src.processor.content_parser import ContentParser
 from src.knowledge_base.repository import RepositoryManager
-from config.agent_prompts import KB_QUERY_PROMPT_TEMPLATE
+from config.agent_prompts import render_prompt
 
 
 class QuestionAnsweringService(IQuestionAnsweringService):
@@ -128,10 +128,13 @@ class QuestionAnsweringService(IQuestionAnsweringService):
         # Get user agent
         user_agent = self.user_context_manager.get_or_create_agent(user_id)
         
-        # Prepare query prompt
-        query_prompt = KB_QUERY_PROMPT_TEMPLATE.format(
-            kb_path=str(kb_path),
-            question=question
+        # Prepare query prompt via versioned registry
+        query_prompt = render_prompt(
+            "kb_query",
+            data={
+                "kb_path": str(kb_path),
+                "question": question,
+            },
         )
         
         # Create query content


### PR DESCRIPTION
Refactor agent prompts into a versioned registry to improve structure, usability, and versioning.

This PR introduces a `PromptRegistry` in `config/agent_prompts.py` that allows defining prompts with IDs, versions, and locales. Helper functions `get_prompt` and `render_prompt` are provided to retrieve and format prompts. Existing agent implementations (`QwenCodeCLIAgent`, `QuestionAnsweringService`) are updated to use this new registry, ensuring all prompts are managed centrally and can be versioned in the future. Backward compatibility for existing prompt constants is maintained.

---
<a href="https://cursor.com/background-agent?bcId=bc-ac70d15e-21d8-4309-bc28-6578e9d27b09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ac70d15e-21d8-4309-bc28-6578e9d27b09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

