### PR TITLE
Decouple message processing from media

### DIFF
--- a/src/bot/handlers.py
+++ b/src/bot/handlers.py
@@ -76,26 +76,23 @@ class BotHandlers:
         self.bot.message_handler(commands=['note'])(self.handle_note_mode)
         self.bot.message_handler(commands=['ask'])(self.handle_ask_mode)
         
-        # Forwarded messages
+        # All supported content types (decoupled from media processing)
+        supported_content_types = [
+            'text', 'photo', 'document', 'video', 'audio', 'voice', 
+            'video_note', 'animation', 'sticker'
+        ]
+        
+        # Forwarded messages (all content types)
         self.bot.message_handler(
-            content_types=['text', 'photo', 'document'],
+            content_types=supported_content_types,
             func=lambda m: self._is_forwarded_message(m)
         )(self.handle_forwarded_message)
         
-        # Regular message handlers
+        # Regular messages (all content types, unified handler)
         self.bot.message_handler(
-            func=lambda m: m.content_type == 'text' 
-            and not self._is_forwarded_message(m) 
-            and not self._is_command_message(m)
-        )(self.handle_text_message)
-        
-        self.bot.message_handler(
-            func=lambda m: m.content_type == 'photo' and not self._is_forwarded_message(m)
-        )(self.handle_photo_message)
-        
-        self.bot.message_handler(
-            func=lambda m: m.content_type == 'document' and not self._is_forwarded_message(m)
-        )(self.handle_document_message)
+            content_types=supported_content_types,
+            func=lambda m: not self._is_forwarded_message(m) and not self._is_command_message(m)
+        )(self.handle_message)
     
     def _is_forwarded_message(self, message: Message) -> bool:
         """Check if message is forwarded"""
@@ -158,7 +155,10 @@ class BotHandlers:
             "• Текстовые сообщения\n"
             "• Репосты новостей или статей\n"
             "• Фотографии с подписями\n"
-            "• Документы\n\n"
+            "• Документы\n"
+            "• Видео с описанием\n"
+            "• Голосовые сообщения\n"
+            "• Аудио файлы\n\n"
             "Бот проанализирует контент и сохранит важную информацию в базу знаний.\n\n"
             "Команды:\n"
             "/help - показать справку\n"
@@ -181,12 +181,17 @@ class BotHandlers:
             "• 📝 Текстовые сообщения\n"
             "• 🔄 Репосты (forwarded messages)\n"
             "• 📷 Фотографии с подписями\n"
-            "• 📄 Документы\n\n"
+            "• 📄 Документы (PDF, DOCX, PPTX, XLSX и др.)\n"
+            "• 🎥 Видео с описанием (текст извлекается)\n"
+            "• 🎵 Аудио файлы (текст извлекается)\n"
+            "• 🎤 Голосовые сообщения (текст извлекается)\n\n"
             "Как это работает:\n"
             "1. Отправьте сообщение или репост\n"
             "2. Бот проанализирует контент\n"
             "3. Извлечет ключевую информацию\n"
             "4. Сохранит в базу знаний в формате Markdown\n\n"
+            "⚠️ Примечание: Для видео, аудио и голосовых сообщений пока извлекается только текст/подпись. "
+            "Полная обработка медиа будет добавлена в будущем.\n\n"
             "**Основные команды:**\n"
             "/start - начать работу с ботом\n"
             "/status - статистика обработки\n"
@@ -367,46 +372,39 @@ class BotHandlers:
     
     # Message handlers
     
-    async def handle_text_message(self, message: Message) -> None:
-        """Handle regular text messages"""
+    async def handle_message(self, message: Message) -> None:
+        """Handle all regular messages (unified handler for all content types)"""
+        # Skip if waiting for settings input
         if self.settings_handlers and message.from_user.id in self.settings_handlers.waiting_for_input:
-            self.logger.info(
-                f"Skipping text message from user {message.from_user.id} "
-                f"- waiting for settings input"
-            )
-            return
+            # Only accept text input in settings mode
+            if message.content_type != 'text':
+                await self.bot.reply_to(
+                    message,
+                    "⚠️ Вы находитесь в режиме настроек. Пожалуйста, отправьте текстовое значение.\n"
+                    "Используйте /cancel для отмены."
+                )
+                return
+            else:
+                # Let settings handler process text input
+                self.logger.info(
+                    f"Skipping text message from user {message.from_user.id} "
+                    f"- waiting for settings input"
+                )
+                return
         
-        self.logger.info(f"Text message from user {message.from_user.id}: {message.text[:50]}...")
-        await self.message_processor.process_message(message)
-    
-    async def handle_photo_message(self, message: Message) -> None:
-        """Handle photo messages"""
-        if self.settings_handlers and message.from_user.id in self.settings_handlers.waiting_for_input:
-            await self.bot.reply_to(
-                message,
-                "⚠️ Вы находитесь в режиме настроек. Фото игнорируются.\n"
-                "Отправьте текстовое значение или используйте /cancel для отмены."
-            )
-            return
+        # Log message info
+        content_type = message.content_type
+        log_msg = f"{content_type.capitalize()} message from user {message.from_user.id}"
+        if content_type == 'text' and message.text:
+            log_msg += f": {message.text[:50]}..."
+        self.logger.info(log_msg)
         
-        self.logger.info(f"Photo message from user {message.from_user.id}")
-        await self.message_processor.process_message(message)
-    
-    async def handle_document_message(self, message: Message) -> None:
-        """Handle document messages"""
-        if self.settings_handlers and message.from_user.id in self.settings_handlers.waiting_for_input:
-            await self.bot.reply_to(
-                message,
-                "⚠️ Вы находитесь в режиме настроек. Документы игнорируются.\n"
-                "Отправьте текстовое значение или используйте /cancel для отмены."
-            )
-            return
-        
-        self.logger.info(f"Document message from user {message.from_user.id}")
+        # Process message regardless of content type
         await self.message_processor.process_message(message)
     
     async def handle_forwarded_message(self, message: Message) -> None:
-        """Handle forwarded messages"""
+        """Handle forwarded messages (all content types)"""
+        # Skip if waiting for settings input
         if self.settings_handlers and message.from_user.id in self.settings_handlers.waiting_for_input:
             await self.bot.reply_to(
                 message,
@@ -415,5 +413,9 @@ class BotHandlers:
             )
             return
         
-        self.logger.info(f"Forwarded message from user {message.from_user.id}")
+        # Log message info
+        content_type = message.content_type
+        self.logger.info(f"Forwarded {content_type} message from user {message.from_user.id}")
+        
+        # Process message regardless of content type
         await self.message_processor.process_message(message)

--- a/src/services/message_processor.py
+++ b/src/services/message_processor.py
@@ -172,7 +172,8 @@ class MessageProcessor(IMessageProcessor):
         Returns:
             Message dictionary
         """
-        return {
+        # Base message data
+        message_dict = {
             'message_id': message.message_id,
             'chat_id': message.chat.id,
             'user_id': message.from_user.id,
@@ -185,6 +186,25 @@ class MessageProcessor(IMessageProcessor):
             'forward_sender_name': message.forward_sender_name,
             'forward_date': message.forward_date,
             'date': message.date,
-            'photo': message.photo,
-            'document': message.document
         }
+        
+        # Add media attachments if present (decoupled from processing logic)
+        # This allows us to capture media info without requiring processing support
+        if hasattr(message, 'photo') and message.photo:
+            message_dict['photo'] = message.photo
+        if hasattr(message, 'document') and message.document:
+            message_dict['document'] = message.document
+        if hasattr(message, 'video') and message.video:
+            message_dict['video'] = message.video
+        if hasattr(message, 'audio') and message.audio:
+            message_dict['audio'] = message.audio
+        if hasattr(message, 'voice') and message.voice:
+            message_dict['voice'] = message.voice
+        if hasattr(message, 'video_note') and message.video_note:
+            message_dict['video_note'] = message.video_note
+        if hasattr(message, 'animation') and message.animation:
+            message_dict['animation'] = message.animation
+        if hasattr(message, 'sticker') and message.sticker:
+            message_dict['sticker'] = message.sticker
+        
+        return message_dict

--- a/tests/test_handlers_async.py
+++ b/tests/test_handlers_async.py
@@ -149,10 +149,24 @@ class TestHandlersAsync:
         assert "Статистика" in call_args[0][1]
     
     @pytest.mark.asyncio
-    async def test_handle_text_message_calls_processor(self, handlers, test_message):
-        """Test that text messages are delegated to message processor"""
+    async def test_handle_message_calls_processor(self, handlers, test_message):
+        """Test that messages are delegated to message processor"""
         # Act
-        await handlers.handle_text_message(test_message)
+        await handlers.handle_message(test_message)
+        # Assert processor was called
+        handlers.message_processor.process_message.assert_awaited_once_with(test_message)
+    
+    @pytest.mark.asyncio
+    async def test_handle_video_message_calls_processor(self, handlers, test_message):
+        """Test that video messages are now processed"""
+        # Set message to video type
+        test_message.content_type = 'video'
+        test_message.video = Mock()
+        test_message.caption = "This is a video caption"
+        
+        # Act
+        await handlers.handle_message(test_message)
+        
         # Assert processor was called
         handlers.message_processor.process_message.assert_awaited_once_with(test_message)
     

--- a/tests/test_handlers_forwarded_fix.py
+++ b/tests/test_handlers_forwarded_fix.py
@@ -177,7 +177,7 @@ class TestHandlersForwardedMessageFix:
         test_message.photo = [Mock()]
         
         # Call handler
-        await handlers.handle_photo_message(test_message)
+        await handlers.handle_message(test_message)
         
         # Verify that reply was sent explaining the message is ignored
         mock_bot.reply_to.assert_called_once()
@@ -196,7 +196,7 @@ class TestHandlersForwardedMessageFix:
         test_message.document = Mock()
         
         # Call handler
-        await handlers.handle_document_message(test_message)
+        await handlers.handle_message(test_message)
         
         # Verify that reply was sent explaining the message is ignored
         mock_bot.reply_to.assert_called_once()
@@ -211,7 +211,7 @@ class TestHandlersForwardedMessageFix:
         handlers.settings_handlers.waiting_for_input[456] = ("KB_PATH", "knowledge_base")
         
         # Call handler
-        await handlers.handle_text_message(test_message)
+        await handlers.handle_message(test_message)
         
         # Verify that no processing happened (no reply_to for processing message)
         # The text should be handled by settings_handlers instead


### PR DESCRIPTION
Decouple message processing from media attachments to ensure all messages with text/captions are processed, even if their media type is not yet fully supported.

Previously, message handlers were only registered for `text`, `photo`, and `document` content types, causing messages with other media (e.g., video, audio) to be ignored. This change introduces a unified message handler for all content types, allowing the bot to extract text/captions from any message, while gracefully logging unsupported media types for future content processing development.

---
<a href="https://cursor.com/background-agent?bcId=bc-b3ad27c9-9207-4341-8090-afa9b37edd06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b3ad27c9-9207-4341-8090-afa9b37edd06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

