### PR TITLE
Handle missing knowledge base files in ask mode

### DIFF
--- a/src/agents/autonomous_agent.py
+++ b/src/agents/autonomous_agent.py
@@ -285,6 +285,13 @@ class AutonomousAgent(BaseAgent):
         self.kb_root_path = kb_root_path or Path("./knowledge_base")
         self.kb_root_path = self.kb_root_path.resolve()
         
+        # Ensure KB root path exists
+        try:
+            self.kb_root_path.mkdir(parents=True, exist_ok=True)
+            logger.info(f"Knowledge base root path ensured: {self.kb_root_path}")
+        except Exception as e:
+            logger.warning(f"Could not create KB root path {self.kb_root_path}: {e}")
+        
         # Vector search manager
         self.vector_search_manager = vector_search_manager
         

--- a/src/agents/tools/kb_reading_tools.py
+++ b/src/agents/tools/kb_reading_tools.py
@@ -171,9 +171,17 @@ class KBListDirectoryTool(BaseTool):
         try:
             # Check if directory exists
             if not full_path.exists():
-                error_msg = f"Directory does not exist: {relative_path}"
-                logger.warning(f"[kb_list_directory] {error_msg}")
-                return {"success": False, "error": error_msg}
+                logger.warning(f"[kb_list_directory] Directory does not exist: {relative_path or 'root'}")
+                return {
+                    "success": True,
+                    "path": relative_path or "root",
+                    "recursive": recursive,
+                    "files": [],
+                    "directories": [],
+                    "file_count": 0,
+                    "directory_count": 0,
+                    "message": "Directory does not exist yet. It will be created when you add files."
+                }
             
             if not full_path.is_dir():
                 error_msg = f"Path is not a directory: {relative_path}"
@@ -261,6 +269,20 @@ class KBSearchFilesTool(BaseTool):
         if not pattern:
             logger.error("[kb_search_files] No pattern provided")
             return {"success": False, "error": "No pattern provided"}
+        
+        # Check if KB root exists
+        if not context.kb_root_path.exists():
+            logger.warning(f"[kb_search_files] KB root does not exist: {context.kb_root_path}")
+            return {
+                "success": True,
+                "pattern": pattern,
+                "case_sensitive": case_sensitive,
+                "files": [],
+                "directories": [],
+                "file_count": 0,
+                "directory_count": 0,
+                "message": "Knowledge base directory does not exist yet. It will be created when you add files."
+            }
         
         try:
             files = []
@@ -364,6 +386,19 @@ class KBSearchContentTool(BaseTool):
         if not query:
             logger.error("[kb_search_content] No query provided")
             return {"success": False, "error": "No query provided"}
+        
+        # Check if KB root exists
+        if not context.kb_root_path.exists():
+            logger.warning(f"[kb_search_content] KB root does not exist: {context.kb_root_path}")
+            return {
+                "success": True,
+                "query": query,
+                "case_sensitive": case_sensitive,
+                "file_pattern": file_pattern,
+                "matches": [],
+                "files_found": 0,
+                "message": "Knowledge base directory does not exist yet. It will be created when you add files."
+            }
         
         try:
             matches = []


### PR DESCRIPTION
Auto-create the knowledge base root directory and add graceful handling to KB reading tools to prevent crashes when the directory is missing.

The bot was crashing with `FileNotFoundError` when attempting to access the `knowledge_base` root or `knowledge_base/topics` if it didn't exist, particularly in "ask mode" where `KB_TOPICS_ONLY` is often true. This PR ensures the root directory is created on agent initialization and that KB reading tools return empty results with a helpful message instead of failing when the directory is absent.

---
<a href="https://cursor.com/background-agent?bcId=bc-9b2cc32b-6963-433c-b4c2-639fa6e7ecb7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9b2cc32b-6963-433c-b4c2-639fa6e7ecb7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

