### PR TITLE
Handle missing knowledge base directory

### DIFF
--- a/src/agents/agent_factory.py
+++ b/src/agents/agent_factory.py
@@ -153,6 +153,13 @@ def _create_autonomous_agent(config: Dict) -> AutonomousAgent:
         kb_root_path = kb_path
         logger.info(f"Agent has full access to knowledge base: {kb_root_path}")
     
+    # Ensure kb_root_path exists
+    try:
+        kb_root_path.mkdir(parents=True, exist_ok=True)
+        logger.debug(f"Ensured KB root path exists: {kb_root_path}")
+    except Exception as e:
+        logger.warning(f"Could not create KB root path {kb_root_path}: {e}")
+    
     # Create autonomous agent
     return AutonomousAgent(
         llm_connector=llm_connector,
@@ -188,11 +195,20 @@ def _create_qwen_cli_agent(config: Dict) -> QwenCodeCLIAgent:
         kb_topics_only = config.get("kb_topics_only", True)
         
         if kb_topics_only:
-            working_directory = str(kb_path / "topics")
+            working_directory_path = kb_path / "topics"
+            working_directory = str(working_directory_path)
             logger.info(f"Restricting Qwen CLI agent to topics folder: {working_directory}")
         else:
+            working_directory_path = kb_path
             working_directory = str(kb_path)
             logger.info(f"Qwen CLI agent has full access to knowledge base: {working_directory}")
+        
+        # Ensure working directory exists
+        try:
+            working_directory_path.mkdir(parents=True, exist_ok=True)
+            logger.debug(f"Ensured working directory exists: {working_directory}")
+        except Exception as e:
+            logger.warning(f"Could not create working directory {working_directory}: {e}")
     
     return QwenCodeCLIAgent(
         config=config,


### PR DESCRIPTION
Ensure knowledge base directories are automatically created and gracefully handle missing directories in KB reading tools to prevent `FileNotFoundError`.

The application crashed with `[Errno 2] No such file or directory: 'knowledge_base/topics'` because the `knowledge_base/topics` directory, used by agents when `KB_TOPICS_ONLY` is enabled, was not created automatically. Additionally, KB reading tools were not robust to cases where these directories might not exist, leading to crashes instead of returning empty results.

---
<a href="https://cursor.com/background-agent?bcId=bc-454ae346-2f07-45f0-8403-80fcf4f9245c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-454ae346-2f07-45f0-8403-80fcf4f9245c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

