### PR TITLE
Удалить лишние инструкции из промпта /ask

### DIFF
--- a/src/agents/qwen_code_cli_agent.py
+++ b/src/agents/qwen_code_cli_agent.py
@@ -257,6 +257,10 @@ class QwenCodeCLIAgent(BaseAgent):
         Returns:
             Formatted prompt string
         """
+        # If content already has a pre-built prompt (e.g., from /ask mode), use it directly
+        if "prompt" in content:
+            return content["prompt"]
+        
         text = content.get("text", "")
         urls = content.get("urls", [])
         


### PR DESCRIPTION
Remove knowledge base creation instructions from the `/ask` mode prompt by using its pre-built prompt directly.

The `_prepare_prompt` method was always wrapping the content with `CONTENT_PROCESSING_PROMPT_TEMPLATE`, even when the `question_answering_service` for `/ask` mode provided a specific `KB_QUERY_PROMPT_TEMPLATE`. This led to the `/ask` prompt incorrectly including instructions meant for `/note` mode. The change ensures that if a 'prompt' field already exists in the content, it is used as-is, preventing the unwanted addition of knowledge base instructions for `/ask` mode.

---
<a href="https://cursor.com/background-agent?bcId=bc-c221bf45-df2a-4621-85f9-82a2ed3cf0b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c221bf45-df2a-4621-85f9-82a2ed3cf0b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

