### PR TITLE
Read dependencies from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,18 +68,24 @@ mcp = [
     "fastmcp>=0.1.0",
 ]
 mem-agent = [
-    # Memory Agent dependencies
-    # Core dependencies
+    # Memory Agent dependencies - Core (platform-independent)
     "transformers>=4.51.0,<4.54.0",
+    "huggingface-hub>=0.23.0",
     "fastmcp>=0.1.0",
     "aiofiles>=23.0.0",
+    "pydantic>=2.0.0",
+    "python-dotenv>=1.0.0",
     "jinja2>=3.0.0",
     "pygments>=2.19.0",
-    "black>=23.0.0",
-    # Platform-specific backends (install manually based on platform):
-    # - macOS: pip install mlx mlx-lm
-    # - Linux with GPU: pip install vllm
-    # - CPU fallback: uses transformers (already included)
+]
+mem-agent-macos = [
+    # Memory Agent dependencies for macOS (MLX backend)
+    "mlx>=0.0.1",
+    "mlx-lm>=0.0.1",
+]
+mem-agent-linux = [
+    # Memory Agent dependencies for Linux/Windows (vLLM backend)
+    "vllm>=0.1.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
Refactor `install_mem_agent.py` to read and install platform-specific dependencies directly from `pyproject.toml` to avoid duplication.

This change centralizes dependency definitions in `pyproject.toml` and allows the installation script to dynamically select the correct backend (MLX for macOS, vLLM for Linux/Windows) based on the platform, improving maintainability and flexibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-227ccd2f-123f-4cfc-a9a9-2ba2a72ed64d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-227ccd2f-123f-4cfc-a9a9-2ba2a72ed64d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

