### PR TITLE
Update mcp config paths and memory directory creation

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -291,15 +291,10 @@ AGENT_ENABLE_FOLDER_MANAGEMENT: true
 
 
 # ───────────────────────────────────────────────────────────────────────────────
-# MCP (Model Context Protocol) Settings (Advanced Feature)
+# MCP (Model Context Protocol) Settings
 # ───────────────────────────────────────────────────────────────────────────────
 # MCP enables integration with external tools and services via the Model Context
 # Protocol. This allows the agent to access additional capabilities beyond built-in tools.
-#
-# ⚠️ REQUIREMENTS:
-# 1. Node.js and npm must be installed
-# 2. Install MCP servers separately (e.g., npm install -g @firstbatch/mem-agent-mcp)
-# 3. Set required API keys in .env file
 #
 # Documentation: docs_site/agents/mcp-tools.md
 
@@ -310,58 +305,99 @@ AGENT_ENABLE_FOLDER_MANAGEMENT: true
 #
 # - true: Enable MCP tools
 #         Allows connecting external tools via MCP protocol
-#         Requires Node.js and MCP servers to be installed
+#         MCP server configs are stored in data/mcp_servers/*.json
 #
 # NOTE: Individual MCP tools must be enabled separately
 AGENT_ENABLE_MCP: false
-
-# ─── Memory Agent Tool (MCP) ───────────────────────────────────────────────────
-# Intelligent memory management using the mem-agent model from HuggingFace.
-# Provides semantic memory storage and retrieval across agent sessions.
-#
-# Model: https://huggingface.co/driaforall/mem-agent
-# Server: https://github.com/firstbatchxyz/mem-agent-mcp
-#
-# Installation:
-#   npm install -g @firstbatch/mem-agent-mcp
 
 # AGENT_ENABLE_MCP_MEMORY: Enable memory agent tool
 #
 # - false: Memory agent disabled (default)
 #
-# - true: Enable intelligent memory management
-#         Agent can store and retrieve memories with semantic understanding
-#         Maintains context across multiple sessions
+# - true: Enable local memory management with mem-agent
+#         Uses HuggingFace model for intelligent memory storage
 #         Requires:
 #         * AGENT_ENABLE_MCP=true
-#         * mem-agent-mcp server installed (npm)
-#         * OPENAI_API_KEY or ANTHROPIC_API_KEY in .env
+#         * Running scripts/install_mem_agent.py first
+#         * Model: driaforall/mem-agent from HuggingFace
 #
-# Provides tools:
-# - mcp_memory_agent: Unified memory tool (store, search, list)
-# - memory_store: Store a memory
-# - memory_search: Search through memories
+# Installation:
+#   python scripts/install_mem_agent.py
+#
+# Memory storage:
+#   Each user's memory is stored in their KB at: {kb_path}/memory/
+#   This ensures per-user isolation and privacy
 AGENT_ENABLE_MCP_MEMORY: false
 
-# MCP_MEMORY_PROVIDER: LLM provider for memory agent
-#
-# Available providers:
-# - "openai": Use OpenAI API (requires OPENAI_API_KEY in .env)
-# - "anthropic": Use Anthropic API (requires ANTHROPIC_API_KEY in .env)
-#
-# NOTE: The memory agent uses LLM to understand and organize memories
-MCP_MEMORY_PROVIDER: "openai"
 
-# MCP_MEMORY_MODEL: Model to use for memory operations
+# ───────────────────────────────────────────────────────────────────────────────
+# Memory Agent Settings (Local LLM)
+# ───────────────────────────────────────────────────────────────────────────────
+# Configuration for the local mem-agent that provides intelligent memory management
+# using a locally-run LLM model. No API keys required.
+
+# MEM_AGENT_MODEL: HuggingFace model ID for memory agent
 #
-# For OpenAI provider:
-# - "gpt-4": Best quality (RECOMMENDED)
-# - "gpt-3.5-turbo": Faster, cheaper
+# Default: driaforall/mem-agent
+# This is a specialized model trained for memory management tasks
+MEM_AGENT_MODEL: "driaforall/mem-agent"
+
+# MEM_AGENT_MODEL_PRECISION: Model quantization precision
 #
-# For Anthropic provider:
-# - "claude-3-opus-20240229": Best quality
-# - "claude-3-sonnet-20240229": Balanced
-MCP_MEMORY_MODEL: "gpt-4"
+# Available options:
+# - "4bit": Smallest, fastest, lowest quality (RECOMMENDED for most users)
+# - "8bit": Balanced size and quality
+# - "fp16": Full precision, highest quality, requires more resources
+MEM_AGENT_MODEL_PRECISION: "4bit"
+
+# MEM_AGENT_BACKEND: Backend for running the model
+#
+# Available options:
+# - "auto": Automatically detect best backend (RECOMMENDED)
+#           * macOS: Uses MLX if available, otherwise transformers
+#           * Linux/Windows: Uses vLLM if available, otherwise transformers
+# - "vllm": Use vLLM backend (fast, for Linux/Windows)
+# - "mlx": Use MLX backend (optimized for Apple Silicon)
+# - "transformers": Use HuggingFace transformers (fallback, slower)
+MEM_AGENT_BACKEND: "auto"
+
+# MEM_AGENT_VLLM_HOST: vLLM server host (only used if backend is vllm)
+MEM_AGENT_VLLM_HOST: "127.0.0.1"
+
+# MEM_AGENT_VLLM_PORT: vLLM server port (only used if backend is vllm)
+MEM_AGENT_VLLM_PORT: 8001
+
+# MEM_AGENT_MEMORY_POSTFIX: Directory name for memory storage within each user's KB
+#
+# Default: "memory"
+# Full path will be: {kb_path}/memory/
+# Each user gets their own isolated memory directory
+MEM_AGENT_MEMORY_POSTFIX: "memory"
+
+# MEM_AGENT_MAX_TOOL_TURNS: Maximum number of tool execution turns
+#
+# Prevents infinite loops in memory operations
+MEM_AGENT_MAX_TOOL_TURNS: 20
+
+# MEM_AGENT_TIMEOUT: Timeout for sandboxed code execution (seconds)
+#
+# Safety limit for memory operations
+MEM_AGENT_TIMEOUT: 20
+
+# MEM_AGENT_FILE_SIZE_LIMIT: Maximum file size in bytes
+#
+# Default: 1MB - prevents memory files from growing too large
+MEM_AGENT_FILE_SIZE_LIMIT: 1048576
+
+# MEM_AGENT_DIR_SIZE_LIMIT: Maximum directory size in bytes
+#
+# Default: 10MB - limits total size of entities directory
+MEM_AGENT_DIR_SIZE_LIMIT: 10485760
+
+# MEM_AGENT_MEMORY_SIZE_LIMIT: Maximum total memory size in bytes
+#
+# Default: 100MB - limits total size of all memory data
+MEM_AGENT_MEMORY_SIZE_LIMIT: 104857600
 
 
 # ───────────────────────────────────────────────────────────────────────────────

--- a/scripts/install_mem_agent.py
+++ b/scripts/install_mem_agent.py
@@ -150,19 +150,16 @@ def download_model(model_id: str, precision: str = "4bit") -> bool:
         return False
 
 
-def create_mcp_server_config(workspace_root: Path, kb_path: Path, memory_postfix: str) -> bool:
+def create_mcp_server_config(workspace_root: Path, memory_postfix: str) -> bool:
     """Create MCP server configuration for mem-agent"""
     print("\n=== Creating MCP Server Configuration ===\n")
     
-    # Get MCP servers directory from config if available
-    if CONFIG_AVAILABLE:
-        mcp_servers_dir = app_settings.get_mcp_servers_dir(kb_path)
-    else:
-        mcp_servers_dir = kb_path / ".mcp_servers"
-    
+    # MCP configs are global (per-user, not per-KB) and stored in data/mcp_servers/
+    mcp_servers_dir = Path("data/mcp_servers")
     mcp_servers_dir.mkdir(parents=True, exist_ok=True)
     
     # Create mem-agent MCP server configuration
+    # Note: Memory directory path will be determined at runtime based on user's KB
     config = {
         "name": "mem-agent",
         "description": "Local memory agent with intelligent memory management using LLM",
@@ -172,8 +169,7 @@ def create_mcp_server_config(workspace_root: Path, kb_path: Path, memory_postfix
             "src.mem_agent.server"
         ],
         "env": {
-            "MEM_AGENT_MEMORY_POSTFIX": memory_postfix,
-            "KB_PATH": str(kb_path)
+            "MEM_AGENT_MEMORY_POSTFIX": memory_postfix
         },
         "working_dir": str(workspace_root),
         "enabled": True
@@ -191,40 +187,16 @@ def create_mcp_server_config(workspace_root: Path, kb_path: Path, memory_postfix
         return False
 
 
-def setup_memory_directory(kb_path: Path, memory_postfix: str) -> bool:
-    """Setup memory directory structure"""
-    print("\n=== Setting Up Memory Directory ===\n")
-    
-    memory_dir = kb_path / memory_postfix
-    memory_dir.mkdir(parents=True, exist_ok=True)
-    
-    # Create initial user.md if it doesn't exist
-    user_md = memory_dir / "user.md"
-    if not user_md.exists():
-        initial_content = """# User Information
-
-This is your personal memory file. The memory agent will store information about you and your relationships here.
-
-## User Relationships
-
-Links to entities will appear here as you interact with the memory agent.
-"""
-        try:
-            with open(user_md, "w", encoding="utf-8") as f:
-                f.write(initial_content)
-            print(f"[✓] Created initial user.md at {user_md}")
-        except Exception as e:
-            print(f"[✗] Failed to create user.md: {e}")
-            return False
-    else:
-        print(f"[✓] user.md already exists at {user_md}")
-    
-    # Create entities directory
-    entities_dir = memory_dir / "entities"
-    entities_dir.mkdir(exist_ok=True)
-    print(f"[✓] Memory directory structure created at {memory_dir}")
-    
-    return True
+def setup_memory_directory_note() -> None:
+    """Print note about memory directory creation"""
+    print("\n=== Memory Directory Setup ===\n")
+    print("[i] Memory directory will be created automatically by the MCP server")
+    print("    when it's first called. This ensures the correct path structure:")
+    print("    knowledge_base/{user-specific-kb}/memory/")
+    print("    ")
+    print("    The memory directory is NOT created during installation because")
+    print("    the specific user's knowledge base name is only known at runtime.")
+    print()
 
 
 def main():
@@ -236,7 +208,6 @@ def main():
     default_model = app_settings.MEM_AGENT_MODEL if CONFIG_AVAILABLE else "driaforall/mem-agent"
     default_precision = app_settings.MEM_AGENT_MODEL_PRECISION if CONFIG_AVAILABLE else "4bit"
     default_memory_postfix = app_settings.MEM_AGENT_MEMORY_POSTFIX if CONFIG_AVAILABLE else "memory"
-    default_kb_path = app_settings.KB_PATH if CONFIG_AVAILABLE else Path("./knowledge_bases/default")
     
     parser.add_argument(
         "--model",
@@ -261,12 +232,6 @@ def main():
         help="Workspace root directory (default: current directory)"
     )
     parser.add_argument(
-        "--kb-path",
-        type=Path,
-        default=default_kb_path,
-        help=f"Knowledge base path (default: {default_kb_path})"
-    )
-    parser.add_argument(
         "--memory-postfix",
         type=str,
         default=default_memory_postfix,
@@ -275,18 +240,14 @@ def main():
     
     args = parser.parse_args()
     
-    # Construct full memory path for display
-    full_memory_path = args.kb_path / args.memory_postfix
-    
     print("=" * 60)
     print("Memory Agent Installation")
     print("=" * 60)
     print(f"\nModel: {args.model}")
     print(f"Precision: {args.precision}")
     print(f"Workspace: {args.workspace}")
-    print(f"Knowledge Base: {args.kb_path}")
     print(f"Memory postfix: {args.memory_postfix}")
-    print(f"Full memory path: {full_memory_path}")
+    print(f"MCP config location: data/mcp_servers/mem-agent.json")
     if CONFIG_AVAILABLE:
         print("[✓] Using settings from config.settings")
     else:
@@ -307,13 +268,11 @@ def main():
     else:
         print("\n[*] Skipping model download (as requested)")
     
-    # Step 3: Setup memory directory
-    if not setup_memory_directory(args.kb_path, args.memory_postfix):
-        print("\n[✗] Installation failed at memory directory setup stage")
-        return 1
+    # Step 3: Print note about memory directory (will be created at runtime)
+    setup_memory_directory_note()
     
     # Step 4: Create MCP server configuration
-    if not create_mcp_server_config(args.workspace, args.kb_path, args.memory_postfix):
+    if not create_mcp_server_config(args.workspace, args.memory_postfix):
         print("\n[✗] Installation failed at MCP server configuration stage")
         return 1
     
@@ -321,16 +280,17 @@ def main():
     print("Installation Complete!")
     print("=" * 60)
     print("\nNext steps:")
-    print("1. The mem-agent MCP server has been registered")
+    print("1. The mem-agent MCP server has been registered in data/mcp_servers/")
     print("2. Enable it in your config.yaml or .env:")
     print("   AGENT_ENABLE_MCP: true")
     print("   AGENT_ENABLE_MCP_MEMORY: true")
-    print(f"3. Memory will be stored in: {full_memory_path}")
-    print(f"   (KB: {args.kb_path} + postfix: {args.memory_postfix})")
+    print("3. Memory will be stored per-user at runtime:")
+    print("   knowledge_base/{user-kb-name}/memory/")
+    print("   The MCP server creates this directory when first called.")
     print("4. You can change settings in config.yaml or .env:")
     print("   - MEM_AGENT_MODEL (default: driaforall/mem-agent)")
     print(f"   - MEM_AGENT_MEMORY_POSTFIX (default: {default_memory_postfix})")
-    print("   - Each user's memory is stored in their KB: kb_path/{postfix}")
+    print("   - Each user's memory is isolated in their own KB")
     print("\n")
     
     return 0


### PR DESCRIPTION
Relocate MCP server configuration, dynamically create memory directories, and update example configuration for the memory agent.

The memory directory (`knowledge_base/{user-specific-kb}/memory/`) needs to be created dynamically at runtime by the MCP server because the specific user's knowledge base name (`user-specific-kb`) is only known during agent execution, not at installation time. This ensures correct per-user memory isolation.

---
<a href="https://cursor.com/background-agent?bcId=bc-ee7a2363-ba3d-43c3-89c2-e7d37a091820"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ee7a2363-ba3d-43c3-89c2-e7d37a091820"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

