### PR TITLE
Check knowledge base path usage

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -16,7 +16,16 @@
 # The knowledge base is used to store and manage documents processed by the bot.
 # Git integration is supported for versioning.
 
-# KB_PATH: Path to the knowledge base directory
+# KNOWLEDGE_BASES_ROOT: Root directory for all knowledge bases (multi-user setup)
+# - This is where all user knowledge bases are stored as subdirectories
+# - Example: ./knowledge_base/my-notes, ./knowledge_base/work-notes, etc.
+# - Can be relative (./knowledge_base) or absolute (/path/to/kbs)
+# - Directory will be created automatically if it doesn't exist
+KNOWLEDGE_BASES_ROOT: ./knowledge_base
+
+# KB_PATH: Path to default/single knowledge base (for standalone usage)
+# - This is used by standalone scripts and examples that work with one KB
+# - For multi-user bot setup, each user's KB is created under KNOWLEDGE_BASES_ROOT
 # - Can be relative (./knowledge_base) or absolute (/path/to/kb)
 # - Directory will be created automatically if it doesn't exist
 KB_PATH: ./knowledge_base

--- a/config/settings.py
+++ b/config/settings.py
@@ -264,9 +264,13 @@ class Settings(BaseSettings):
     )
     
     # Knowledge Base Settings (can be in YAML)
+    KNOWLEDGE_BASES_ROOT: Path = Field(
+        default=Path("./knowledge_base"),
+        description="Root directory for all knowledge bases (multi-KB setup)"
+    )
     KB_PATH: Path = Field(
         default=Path("./knowledge_base"),
-        description="Path to knowledge base"
+        description="Path to default/single knowledge base (for standalone usage)"
     )
     KB_TOPICS_ONLY: bool = Field(
         default=True,

--- a/src/bot/settings_manager.py
+++ b/src/bot/settings_manager.py
@@ -42,6 +42,7 @@ class SettingsInspector:
         "QWEN_": "credentials",
         "GITHUB_": "credentials",
         "AGENT_": "agent",
+        "KNOWLEDGE_": "knowledge_base",
         "KB_": "knowledge_base",
         "MESSAGE_": "processing",
         "PROCESSED_": "processing",

--- a/src/core/service_container.py
+++ b/src/core/service_container.py
@@ -50,7 +50,7 @@ def configure_services(container: Container) -> None:
     
     container.register(
         "repo_manager",
-        lambda c: RepositoryManager(base_path="./knowledge_bases"),
+        lambda c: RepositoryManager(base_path=str(c.get("settings").KNOWLEDGE_BASES_ROOT)),
         singleton=True
     )
     

--- a/src/knowledge_base/repository.py
+++ b/src/knowledge_base/repository.py
@@ -27,7 +27,7 @@ except ImportError:
 class RepositoryManager:
     """Manages KB repository (local or GitHub-based)"""
     
-    def __init__(self, base_path: str = "./knowledge_bases"):
+    def __init__(self, base_path: str = "./knowledge_base"):
         """
         Initialize repository manager
         


### PR DESCRIPTION
Unify knowledge base root path configuration to resolve inconsistencies between hardcoded paths and settings.

Previously, `RepositoryManager` hardcoded `./knowledge_bases` for the root directory of all knowledge bases, while `settings.KB_PATH` was `./knowledge_base`. This led to KBs being created in an unexpected plural directory. This PR introduces `KNOWLEDGE_BASES_ROOT` to explicitly define the root for multiple KBs and ensures consistent path usage across the application.

---
<a href="https://cursor.com/background-agent?bcId=bc-477f4157-5bf1-4d5a-bd20-0e029716c8dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-477f4157-5bf1-4d5a-bd20-0e029716c8dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

